### PR TITLE
AccreditedApiKeysMiddleware - Tratativa array_flip

### DIFF
--- a/src/Middlewares/AccreditedApiKeysMiddleware.php
+++ b/src/Middlewares/AccreditedApiKeysMiddleware.php
@@ -42,6 +42,7 @@ class AccreditedApiKeysMiddleware
                                                array $accreditedApiKeys,
                                                string $xApiKeyHeader): Response
     {
+        $accreditedApiKeys = array_filter($accreditedApiKeys);
         $xApiKeyName = array_flip($accreditedApiKeys)[$xApiKeyHeader];
         $apiName = config('app.api-name', 'UnknowApi');
         $response->headers->set('Welcome-Message', "Welcome to the {$apiName}. You are using the x-api-key credential: {$xApiKeyName}");


### PR DESCRIPTION
Aplicada tratativa para caso o valor passado para as configurações de AccreditedApiKeysMiddleware seja nula (variavel não está no .env ou está null no .env) não de erro 500.