### PR TITLE
(LOG-9610) - AccreditedApiKeysMiddleware public routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,41 @@ $app->routeMiddleware([
 ]);
 ```
 
+#### AccreditedApiKeysMiddleware
+
+> It is a class that provides a first level of security for your api. The best analogy is that middleware
+> is your "API guest list". <br> <br>
+> You need to register a configuration file called accreditedApiKeys, with all 
+> the api-keys that can request your api. <br> <br>
+> Therefore, if the request does not contain the x-api-key header or a allowed value, the API denies the request 
+> with the security exception. <br> <br>
+> It is recommended to use as a global middleware, and if you need to avoid this middleware for some routes, just 
+> insert into the public route group.
+
+``` php
+// config/accreditedApiKeys.php
+return [
+    'api-1' => env('API_1_X_API_KEY'),
+    'api-2' => env('API_2_X_API_KEY'),
+    'api-3' => env('API_3_X_API_KEY'),
+];
+
+
+// bootstrap/app.php
+$app->configure('accreditedApiKeys');
+
+// Using in global mode
+$app->middleware([
+    Logcomex\PhpUtils\Middleware\AccreditedApiKeysMiddleware::class,
+]);
+
+
+// routes/api.php
+$router->group(['prefix' => 'public',], function () use ($router) {
+    $router->get('test', 'Controller@test');// this route does not need x-api-key validation
+});
+```
+
 ## Singletons  
 
 > They're a pack of Singleton classes.
@@ -296,7 +331,6 @@ Master <br>
  - [ ] Logs Package Doc
 	 - [ ] RequestLog Doc
  - [ ] Middlewares Package Doc
-	 - [ ] AccreditedApiKeysMiddleware Doc
 	 - [ ] AllowedHostsMiddleware Doc
 	 - [ ] CorsMiddleware Doc
 

--- a/src/Middlewares/AccreditedApiKeysMiddleware.php
+++ b/src/Middlewares/AccreditedApiKeysMiddleware.php
@@ -21,6 +21,12 @@ class AccreditedApiKeysMiddleware
      */
     public function handle(Request $request, Closure $next): Response
     {
+        $requestUriBasePath = $this->extractRequestBasePath($request->getRequestUri());
+        $isPublicRoute = preg_match('/public/', $requestUriBasePath);
+        if ($isPublicRoute) {
+            return $next($request);
+        }
+
         $xApiKeyHeader = $request->header('x-api-key', '');
         $accreditedApiKeys = config('accreditedApiKeys', []);
 
@@ -72,5 +78,17 @@ class AccreditedApiKeysMiddleware
                 Response::HTTP_UNAUTHORIZED
             );
         }
+    }
+
+    /**
+     * @param string $requestUri
+     * @return string
+     */
+    public function extractRequestBasePath(string $requestUri): string
+    {
+        $requestUriExploded = explode('/', $requestUri);
+        $requestUriExploded = array_filter($requestUriExploded);
+
+        return array_shift($requestUriExploded) ?? '';
     }
 }

--- a/src/Middlewares/AccreditedApiKeysMiddleware.php
+++ b/src/Middlewares/AccreditedApiKeysMiddleware.php
@@ -23,6 +23,7 @@ class AccreditedApiKeysMiddleware
     {
         $requestUriBasePath = $this->extractRequestBasePath($request->getRequestUri());
         $isPublicRoute = preg_match('/public/', $requestUriBasePath);
+
         if ($isPublicRoute) {
             return $next($request);
         }

--- a/src/Middlewares/TracerMiddleware.php
+++ b/src/Middlewares/TracerMiddleware.php
@@ -39,7 +39,8 @@ class TracerMiddleware
 
         $requestHeaders = array_map('strtolower', array_keys($request->headers->all()));
         if (!empty($traceHeadersAvailableInRequest = array_intersect($requestHeaders, $traceHeadersOptions))) {
-            $traceHeaderValue = $request->header($traceHeadersAvailableInRequest[0]);
+            $traceHeaderKey = array_shift($traceHeadersAvailableInRequest);
+            $traceHeaderValue = $request->header($traceHeaderKey);
         }
 
         TracerSingleton::setTraceValue($traceHeaderValue);


### PR DESCRIPTION
## :package: Conteúdo

- Documentado middleware AccreditedApiKeysMiddleware.php
- Alterado AccreditedApiKeysMiddleware.php para não aplicar validação em rotas dentro do grupo "public"

## :heavy_check_mark: Tarefa(s)

- LOG-9610
