### PR TITLE
(LOG-11568) - Fix no middleware de response time no php-utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,12 +196,12 @@ $app->register(Your\Provider\AuthServiceProvider::class);
 
 // Using in global mode
 $app->middleware([
-    Logcomex\PhpUtils\Middleware\AuthenticateMiddleware::class,
+    Logcomex\PhpUtils\Middlewares\AuthenticateMiddleware::class,
 ]);
 
 // Or, by specific route
 $app->routeMiddleware([
-    'auth' => Logcomex\PhpUtils\Middleware\AuthenticateMiddleware::class,
+    'auth' => Logcomex\PhpUtils\Middlewares\AuthenticateMiddleware::class,
 ]);
 ```
 
@@ -240,8 +240,8 @@ $app->configure('requestLog');
 
 // Using in global mode
 $app->middleware([
-    Logcomex\PhpUtils\Middleware\TracerMiddleware::class, // If you gonna use tracer, it must be above the requestlog
-    Logcomex\PhpUtils\Middleware\RequestLogMiddleware::class, // And after trace, you need the request log
+    Logcomex\PhpUtils\Middlewares\TracerMiddleware::class, // If you gonna use tracer, it must be above the requestlog
+    Logcomex\PhpUtils\Middlewares\RequestLogMiddleware::class, // And after trace, you need the request log
 ]);
 ```
 
@@ -275,7 +275,7 @@ Usage:
 ``` php
 // Using in global mode
 $app->middleware([
-    Logcomex\PhpUtils\Middleware\ResponseTimeLogMiddleware::class,
+    Logcomex\PhpUtils\Middlewares\ResponseTimeLogMiddleware::class,
 ]);
 
 // Using in specific routes
@@ -311,13 +311,13 @@ $app->configure('tracer');
 
 // Using in global mode
 $app->middleware([
-    Logcomex\PhpUtils\Middleware\TracerMiddleware::class,
+    Logcomex\PhpUtils\Middlewares\TracerMiddleware::class,
     // the other middlewares
 ]);
 
 // Or, by specific route
 $app->routeMiddleware([
-    'tracer' => Logcomex\PhpUtils\Middleware\TracerMiddleware::class,
+    'tracer' => Logcomex\PhpUtils\Middlewares\TracerMiddleware::class,
 ]);
 ```
 
@@ -346,7 +346,7 @@ $app->configure('accreditedApiKeys');
 
 // Using in global mode
 $app->middleware([
-    Logcomex\PhpUtils\Middleware\AccreditedApiKeysMiddleware::class,
+    Logcomex\PhpUtils\Middlewares\AccreditedApiKeysMiddleware::class,
 ]);
 
 

--- a/bootstrap/start.php
+++ b/bootstrap/start.php
@@ -42,7 +42,7 @@ $app->router->group([], function ($router) {
     $router->group(['middleware' => ['response-time-log']], function () use ($router, $routeFunction) {
         $router->get('response-time-log-middleware', function() {
             sleep(2);
-            return 'Request should spend more than 2 seconds';
+            return response()->json('Request should spend more than 2 seconds');
         });
     });
     $router->group(['middleware' => ['allowed-hosts']], function () use ($router, $routeFunction) {

--- a/bootstrap/start.php
+++ b/bootstrap/start.php
@@ -42,7 +42,7 @@ $app->router->group([], function ($router) {
     $router->group(['middleware' => ['response-time-log']], function () use ($router, $routeFunction) {
         $router->get('response-time-log-middleware', function() {
             sleep(2);
-            return response()->json('Request should spend more than 2 seconds');
+            return response()->json('Request should spend more than 2 seconds.');
         });
     });
     $router->group(['middleware' => ['allowed-hosts']], function () use ($router, $routeFunction) {

--- a/src/Middlewares/ResponseTimeLogMiddleware.php
+++ b/src/Middlewares/ResponseTimeLogMiddleware.php
@@ -63,7 +63,7 @@ class ResponseTimeLogMiddleware
             app('ResponseTimeLog')->save($responseTimeLogDto);
         }
 
-        return response()->json($response);
+        return $response;
     }
 
     /**

--- a/tests/Middlewares/ResponseTimeLogMiddlewareUnitTest.php
+++ b/tests/Middlewares/ResponseTimeLogMiddlewareUnitTest.php
@@ -38,13 +38,22 @@ class ResponseTimeLogMiddlewareUnitTest extends TestCase
         $this->expectExceptionToken($response->response->exception, ErrorEnum::PHU007);
     }
 
+    public function testRequestUsingMiddleware_ShouldReturnJsonWithSpecificContent(): void
+    {
+        $this->get('/response-time-log-middleware');
+        $this->assertJsonStringEqualsJsonString(
+            '"Request should spend more than 2 seconds."',
+            $this->response->getContent()
+        );
+    }
+
     public function testRequestUsingMiddlewareWithoutGlobalFrameworkStart(): void
     {
-        $response = $this->call('get', '/response-time-log-middleware');
+        $this->get('/response-time-log-middleware');
         $this->shouldReturnJson();
 
         if (!defined('GLOBAL_FRAMEWORK_START')) {
-            $this->assertNull($response->headers->get('response-time-log'));
+            $this->assertNull($this->response->headers->get('response-time-log'));
         }
     }
 
@@ -54,9 +63,9 @@ class ResponseTimeLogMiddlewareUnitTest extends TestCase
             define('GLOBAL_FRAMEWORK_START', microtime(true));
         }
 
-        $response = $this->call('get', '/response-time-log-middleware');
+        $this->get('/response-time-log-middleware');
         $this->shouldReturnJson();
-        $this->assertGreaterThan(2, $response->headers->get('response-time-log'));
+        $this->assertGreaterThan(2, $this->response->headers->get('response-time-log'));
     }
 }
 

--- a/tests/Middlewares/ResponseTimeLogMiddlewareUnitTest.php
+++ b/tests/Middlewares/ResponseTimeLogMiddlewareUnitTest.php
@@ -44,7 +44,7 @@ class ResponseTimeLogMiddlewareUnitTest extends TestCase
         $this->shouldReturnJson();
 
         if (!defined('GLOBAL_FRAMEWORK_START')) {
-            $this->assertNull($response->original->headers->get('response-time-log'));
+            $this->assertNull($response->headers->get('response-time-log'));
         }
     }
 
@@ -56,7 +56,7 @@ class ResponseTimeLogMiddlewareUnitTest extends TestCase
 
         $response = $this->call('get', '/response-time-log-middleware');
         $this->shouldReturnJson();
-        $this->assertGreaterThan(2, $response->original->headers->get('response-time-log'));
+        $this->assertGreaterThan(2, $response->headers->get('response-time-log'));
     }
 }
 


### PR DESCRIPTION
## :package: Conteúdo

- Ajustado o return/JsonResponse do middleware de request time response.
- Corrigidos alguns typos no README.

## :heavy_check_mark: Tarefa(s)

- [LOG-11568](https://logcomex.atlassian.net/browse/LOG-11568)

## :eyes: Tarefa de Code Review (CR)

- [LOG-11460](https://logcomex.atlassian.net/browse/LOG-11460)
