### PR TITLE
(LOG-12003) Fix no php-utils - uniformizar a data gerada por diferentes versões do Carbon para salvar response time de diferentes APIs

### DIFF
--- a/src/Middlewares/ResponseTimeLogMiddleware.php
+++ b/src/Middlewares/ResponseTimeLogMiddleware.php
@@ -56,7 +56,7 @@ class ResponseTimeLogMiddleware
                 'endpoint' => $request->fullUrl(),
                 'response_time' => $responseTime,
                 'payload' => $request->all(),
-                'created_at' => Carbon::now(),
+                'created_at' => Carbon::now()->format('Y-m-d\TH:i:s.u\Z'),
             ]);
             $response->headers->set('Response-Time-Log', $responseTime);
 


### PR DESCRIPTION
## :package: Conteúdo

- Ajustado o format de data gerado por diferentes versões do Carbon utilizado no created_at do ResponseTimePayloadDto.

## :heavy_check_mark: Tarefa(s)

- [LOG-12003](https://logcomex.atlassian.net/browse/LOG-12003)

## :eyes: Tarefa de Code Review (CR)
- [LOG-11460](https://logcomex.atlassian.net/browse/LOG-11460)
