### PR TITLE
(LOG-12710) - Ligar o medidor de requests (middleware) para todos os sistemas

### DIFF
--- a/src/Middlewares/ResponseTimeLogMiddleware.php
+++ b/src/Middlewares/ResponseTimeLogMiddleware.php
@@ -32,10 +32,10 @@ class ResponseTimeLogMiddleware
     /**
      * @param Request $request
      * @param Closure $next
-     * @return JsonResponse
+     * @return mixed
      * @throws BadImplementationException
      */
-    public function handle(Request $request, Closure $next): JsonResponse
+    public function handle(Request $request, Closure $next)
     {
         $response = $next($request);
 


### PR DESCRIPTION
## :package: Conteúdo

- Removido tipo de retorno na ResponseTimeLogMiddleware->handle para compatibilidade.

## :heavy_check_mark: Tarefa(s)

- [LOG-12710](https://logcomex.atlassian.net/browse/LOG-12710)

## :eyes: Tarefa de Code Review (CR)

- [LOG-11460](https://logcomex.atlassian.net/browse/LOG-11460)
