### PR TITLE
(LOG-28734) - Ajustar tipo de $exception no PHP-Utils (severe + error)

### DIFF
--- a/src/Loggers/LogcomexLogger.php
+++ b/src/Loggers/LogcomexLogger.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\Log;
 use Logcomex\PhpUtils\Helpers\ExceptionHelper;
 use Logcomex\PhpUtils\Singletons\TracerSingleton;
+use TypeError;
 
 /**
  * Class LogcomexLogger
@@ -58,9 +59,9 @@ class LogcomexLogger
     /**
      * @param string $token
      * @param array $context
-     * @param Exception|null $exception
+     * @param TypeError|null $exception
      */
-    public function error(string $token, $context = [], Exception $exception = null): void
+    public function error(string $token, $context = [], TypeError $exception = null): void
     {
         $traceId = TracerSingleton::getTraceValue();
         $context = self::treatContext($context, $exception);
@@ -82,9 +83,9 @@ class LogcomexLogger
     /**
      * @param string $token
      * @param array $context
-     * @param Exception|null $exception
+     * @param TypeError|null $exception
      */
-    public function severe(string $token, $context = [], Exception $exception = null): void
+    public function severe(string $token, $context = [], TypeError $exception = null): void
     {
         $traceId = TracerSingleton::getTraceValue();
         $context = self::treatContext($context, $exception);

--- a/src/Loggers/LogcomexLogger.php
+++ b/src/Loggers/LogcomexLogger.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\Log;
 use Logcomex\PhpUtils\Helpers\ExceptionHelper;
 use Logcomex\PhpUtils\Singletons\TracerSingleton;
-use TypeError;
+use Throwable;
 
 /**
  * Class LogcomexLogger
@@ -25,7 +25,7 @@ class LogcomexLogger
      * @param Exception|null $exception
      * @return array
      */
-    public static function treatContext($context = [], Exception $exception = null): array
+    public static function treatContext($context = [], Throwable $exception = null): array
     {
         $context = $context instanceof Arrayable
             ? $context->toArray()
@@ -59,9 +59,9 @@ class LogcomexLogger
     /**
      * @param string $token
      * @param array $context
-     * @param TypeError|null $exception
+     * @param Throwable|null $exception
      */
-    public function error(string $token, $context = [], TypeError $exception = null): void
+    public function error(string $token, $context = [], Throwable $exception = null): void
     {
         $traceId = TracerSingleton::getTraceValue();
         $context = self::treatContext($context, $exception);
@@ -73,7 +73,7 @@ class LogcomexLogger
      * @param array $context
      * @param Exception|null $exception
      */
-    public function debug(string $message, $context = [], Exception $exception = null): void
+    public function debug(string $message, $context = [], Throwable $exception = null): void
     {
         $traceId = TracerSingleton::getTraceValue();
         $context = self::treatContext($context, $exception);
@@ -83,9 +83,9 @@ class LogcomexLogger
     /**
      * @param string $token
      * @param array $context
-     * @param TypeError|null $exception
+     * @param Throwable|null $exception
      */
-    public function severe(string $token, $context = [], TypeError $exception = null): void
+    public function severe(string $token, $context = [], Throwable $exception = null): void
     {
         $traceId = TracerSingleton::getTraceValue();
         $context = self::treatContext($context, $exception);

--- a/src/Loggers/LogcomexLogger.php
+++ b/src/Loggers/LogcomexLogger.php
@@ -2,7 +2,6 @@
 
 namespace Logcomex\PhpUtils\Loggers;
 
-use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\Log;
 use Logcomex\PhpUtils\Helpers\ExceptionHelper;
@@ -22,7 +21,7 @@ class LogcomexLogger
 
     /**
      * @param array $context
-     * @param Exception|null $exception
+     * @param Throwable|null $exception
      * @return array
      */
     public static function treatContext($context = [], Throwable $exception = null): array
@@ -71,7 +70,7 @@ class LogcomexLogger
     /**
      * @param string $message
      * @param array $context
-     * @param Exception|null $exception
+     * @param Throwable|null $exception
      */
     public function debug(string $message, $context = [], Throwable $exception = null): void
     {


### PR DESCRIPTION
## :package: Conteúdo

- Substituir parâmetro Exception por Throwable nas funções relacionadas a classe LogcomexLogger

## :heavy_check_mark: Tarefa(s)

- [LOG-27718](https://logcomex.atlassian.net/browse/LOG-27718)

## :eyes: Link da tarefa de code review:

- [LOG-28228](https://logcomex.atlassian.net/browse/LOG-28228)

## :test_tube: Justificativa de No Test Needed

- Exception implementa Throwable
