### PR TITLE
(feature/log-32405_0) MsCore :: adicionar base url na saida dos logs

### DIFF
--- a/src/Helpers/HttpHelper.php
+++ b/src/Helpers/HttpHelper.php
@@ -79,7 +79,9 @@ class HttpHelper
      */
     public function __call($method, $args)
     {
-        $urlPath = parse_url($args[0] ?? '')['path'];
+        $url = parse_url($args[0]);
+        $urlHost = $url['host'] ?? '';
+        $urlPath =  $url['path'] ?? '';
 
         if (!empty($tracerValue = TracerSingleton::getTraceValue())) {
             $args = self::propagateTracerValue($tracerValue, $args);
@@ -87,7 +89,11 @@ class HttpHelper
 
         Logger::info(
             LogEnum::REQUEST_HTTP_OUT,
-            ['http_url_request_out' => $urlPath, 'payload' => $args,]
+            [
+                'base_url' => $urlHost,
+                'http_url_request_out' => $urlPath,
+                'payload' => $args,
+            ]
         );
 
         // Tratativa criada pra endpoint mockados,

--- a/tests/Helpers/HttpHelperUnitTest.php
+++ b/tests/Helpers/HttpHelperUnitTest.php
@@ -390,6 +390,7 @@ class HttpHelperUnitTest extends TestCase
 
         $this->assertLogContent(LogEnum::REQUEST_HTTP_OUT);
         $this->assertLogContent('http_url_request_out');
+        $this->assertLogContent('base_url');
         $this->assertLogContent('payload');
     }
 


### PR DESCRIPTION

## :package: Conteúdo

- Inclusão da informação de base_url(host) nos logs setados na magic method  __call() do HttpHelper.php.

## :heavy_check_mark: Tarefa(s)

- LOG-32405

## :eyes: Tarefa de Code Review (CR)
- LOG-33071
