### PR TITLE
(LOG-36885) - Corrigir tipagem php-utils

### DIFF
--- a/src/Handlers/ExceptionHandler.php
+++ b/src/Handlers/ExceptionHandler.php
@@ -46,7 +46,7 @@ class ExceptionHandler extends Handler
      * @param Throwable $throwable
      * @return array
      */
-    public static function exportThrowableToArray(Throwable $throwable): array
+    public static function exportExceptionToArray(Throwable $throwable): array
     {
         if (method_exists($throwable, 'toArray')) {
             return $throwable->toArray();
@@ -71,7 +71,7 @@ class ExceptionHandler extends Handler
      */
     public function report(Exception $exception): void
     {
-        $treatedException = self::exportThrowableToArray($exception);
+        $treatedException = self::exportExceptionToArray($exception);
         $traceId = TracerSingleton::getTraceValue();
 
         Log::error("[[REQUEST_ERROR]] | {$traceId} |", $treatedException);

--- a/src/Handlers/ExceptionHandler.php
+++ b/src/Handlers/ExceptionHandler.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Throwable;
 
 /**
  * Class ExceptionHandler
@@ -42,21 +43,21 @@ class ExceptionHandler extends Handler
     ];
 
     /**
-     * @param Exception $exception
+     * @param Throwable $throwable
      * @return array
      */
-    public static function exportExceptionToArray(Exception $exception): array
+    public static function exportThrowableToArray(Throwable $throwable): array
     {
-        if (method_exists($exception, 'toArray')) {
-            return $exception->toArray();
+        if (method_exists($throwable, 'toArray')) {
+            return $throwable->toArray();
         }
 
         return [
-            'exception-class' => class_basename($exception),
-            'message' => $exception->getMessage(),
-            'file' => $exception->getFile(),
-            'line' => $exception->getLine(),
-            'code' => $exception->getCode(),
+            'exception-class' => class_basename($throwable),
+            'message' => $throwable->getMessage(),
+            'file' => $throwable->getFile(),
+            'line' => $throwable->getLine(),
+            'code' => $throwable->getCode(),
         ];
     }
 
@@ -70,7 +71,7 @@ class ExceptionHandler extends Handler
      */
     public function report(Exception $exception): void
     {
-        $treatedException = self::exportExceptionToArray($exception);
+        $treatedException = self::exportThrowableToArray($exception);
         $traceId = TracerSingleton::getTraceValue();
 
         Log::error("[[REQUEST_ERROR]] | {$traceId} |", $treatedException);

--- a/tests/Handlers/ExceptionHandlerUnitTest.php
+++ b/tests/Handlers/ExceptionHandlerUnitTest.php
@@ -44,7 +44,7 @@ class ExceptionHandlerUnitTest extends TestCase
     {
         $exception = new ApiException('T01', 'Teste', 404);
 
-        $response = $this->handler::exportThrowableToArray($exception);
+        $response = $this->handler::exportExceptionToArray($exception);
 
         $this->assertIsArray($response);
     }
@@ -56,7 +56,7 @@ class ExceptionHandlerUnitTest extends TestCase
     {
         $exception = new Exception('Teste', 100);
 
-        $exceptionArray = $this->handler::exportThrowableToArray($exception);
+        $exceptionArray = $this->handler::exportExceptionToArray($exception);
         $this->assertIsArray($exceptionArray);
         $this->assertEquals('Exception', $exceptionArray['exception-class']);
         $this->assertEquals('Teste', $exceptionArray['message']);

--- a/tests/Handlers/ExceptionHandlerUnitTest.php
+++ b/tests/Handlers/ExceptionHandlerUnitTest.php
@@ -44,7 +44,7 @@ class ExceptionHandlerUnitTest extends TestCase
     {
         $exception = new ApiException('T01', 'Teste', 404);
 
-        $response = $this->handler::exportExceptionToArray($exception);
+        $response = $this->handler::exportThrowableToArray($exception);
 
         $this->assertIsArray($response);
     }
@@ -56,7 +56,7 @@ class ExceptionHandlerUnitTest extends TestCase
     {
         $exception = new Exception('Teste', 100);
 
-        $exceptionArray = $this->handler::exportExceptionToArray($exception);
+        $exceptionArray = $this->handler::exportThrowableToArray($exception);
         $this->assertIsArray($exceptionArray);
         $this->assertEquals('Exception', $exceptionArray['exception-class']);
         $this->assertEquals('Teste', $exceptionArray['message']);


### PR DESCRIPTION
## :package: Conteúdo

- Corrigido a tipagem do exportExceptionToArray para Throwable ao invés de Exception

## :heavy_check_mark: Tarefa(s)
- [LOG-36238](https://logcomex.atlassian.net/browse/LOG-36238)
## :eyes: Tarefa de Code Review
- [LOG-35981](https://logcomex.atlassian.net/browse/LOG-35981)

