### PR TITLE
(LOG-36885) - Corrigir tipagem php-utils

### DIFF
--- a/src/Handlers/ExceptionHandler.php
+++ b/src/Handlers/ExceptionHandler.php
@@ -42,21 +42,21 @@ class ExceptionHandler extends Handler
     ];
 
     /**
-     * @param Throwable $exception
+     * @param Throwable $throwable
      * @return array
      */
-    public static function exportExceptionToArray(Throwable $exception): array
+    public static function exportThrowableToArray(Throwable $throwable): array
     {
-        if (method_exists($exception, 'toArray')) {
-            return $exception->toArray();
+        if (method_exists($throwable, 'toArray')) {
+            return $throwable->toArray();
         }
 
         return [
-            'exception-class' => class_basename($exception),
-            'message' => $exception->getMessage(),
-            'file' => $exception->getFile(),
-            'line' => $exception->getLine(),
-            'code' => $exception->getCode(),
+            'exception-class' => class_basename($throwable),
+            'message' => $throwable->getMessage(),
+            'file' => $throwable->getFile(),
+            'line' => $throwable->getLine(),
+            'code' => $throwable->getCode(),
         ];
     }
 
@@ -70,7 +70,7 @@ class ExceptionHandler extends Handler
      */
     public function report(Throwable $exception): void
     {
-        $treatedException = self::exportExceptionToArray($exception);
+        $treatedException = self::exportThrowableToArray($exception);
         $traceId = TracerSingleton::getTraceValue();
 
         Log::error("[[REQUEST_ERROR]] | {$traceId} |", $treatedException);

--- a/src/Handlers/ExceptionHandler.php
+++ b/src/Handlers/ExceptionHandler.php
@@ -45,7 +45,7 @@ class ExceptionHandler extends Handler
      * @param Throwable $throwable
      * @return array
      */
-    public static function exportThrowableToArray(Throwable $throwable): array
+    public static function exportExceptionToArray(Throwable $throwable): array
     {
         if (method_exists($throwable, 'toArray')) {
             return $throwable->toArray();
@@ -70,7 +70,7 @@ class ExceptionHandler extends Handler
      */
     public function report(Throwable $exception): void
     {
-        $treatedException = self::exportThrowableToArray($exception);
+        $treatedException = self::exportExceptionToArray($exception);
         $traceId = TracerSingleton::getTraceValue();
 
         Log::error("[[REQUEST_ERROR]] | {$traceId} |", $treatedException);

--- a/tests/Handlers/ExceptionHandlerUnitTest.php
+++ b/tests/Handlers/ExceptionHandlerUnitTest.php
@@ -44,7 +44,7 @@ class ExceptionHandlerUnitTest extends TestCase
     {
         $exception = new ApiException('T01', 'Teste', 404);
 
-        $response = $this->handler::exportThrowableToArray($exception);
+        $response = $this->handler::exportExceptionToArray($exception);
 
         $this->assertIsArray($response);
     }
@@ -56,7 +56,7 @@ class ExceptionHandlerUnitTest extends TestCase
     {
         $exception = new Exception('Teste', 100);
 
-        $exceptionArray = $this->handler::exportThrowableToArray($exception);
+        $exceptionArray = $this->handler::exportExceptionToArray($exception);
         $this->assertIsArray($exceptionArray);
         $this->assertEquals('Exception', $exceptionArray['exception-class']);
         $this->assertEquals('Teste', $exceptionArray['message']);

--- a/tests/Handlers/ExceptionHandlerUnitTest.php
+++ b/tests/Handlers/ExceptionHandlerUnitTest.php
@@ -44,7 +44,7 @@ class ExceptionHandlerUnitTest extends TestCase
     {
         $exception = new ApiException('T01', 'Teste', 404);
 
-        $response = $this->handler::exportExceptionToArray($exception);
+        $response = $this->handler::exportThrowableToArray($exception);
 
         $this->assertIsArray($response);
     }
@@ -56,7 +56,7 @@ class ExceptionHandlerUnitTest extends TestCase
     {
         $exception = new Exception('Teste', 100);
 
-        $exceptionArray = $this->handler::exportExceptionToArray($exception);
+        $exceptionArray = $this->handler::exportThrowableToArray($exception);
         $this->assertIsArray($exceptionArray);
         $this->assertEquals('Exception', $exceptionArray['exception-class']);
         $this->assertEquals('Teste', $exceptionArray['message']);


### PR DESCRIPTION
## :package: Conteúdo

- Corrigido a tipagem do exportExceptionToArray para Throwable ao invés de Exception

## :heavy_check_mark: Tarefa(s)
- [LOG-36238](https://logcomex.atlassian.net/browse/LOG-36238)
## :eyes: Tarefa de Code Review
- [LOG-35981](https://logcomex.atlassian.net/browse/LOG-35981)

