### PR TITLE
(LOG-55667) - Medir tempo de request para a fonte app importador

### DIFF
--- a/src/Helpers/HttpHelper.php
+++ b/src/Helpers/HttpHelper.php
@@ -92,15 +92,8 @@ class HttpHelper
         // se não estiver registro no contrato de mocks,
         // será feita a requisição normalmente.
         if ($this->isTestMode()) {
+            $initialTime = round(microtime(true));
             try {
-                Logger::info(
-                    LogEnum::REQUEST_HTTP_OUT,
-                    [
-                        'base_url' => $urlHost,
-                        'http_url_request_out' => $urlPath,
-                        'payload' => $args,
-                    ]
-                );
                 if (!$this->isMockedEndpoint($urlPath)) {
                     throw new BadImplementationException(
                         ErrorEnum::PHU003,
@@ -126,6 +119,16 @@ class HttpHelper
 
                 return $clientMock->request('GET', '/');
             } finally {
+                $finalTime = round(microtime(true));
+                Logger::info(
+                    LogEnum::REQUEST_HTTP_OUT,
+                    [
+                        'base_url' => $urlHost,
+                        'http_url_request_out' => $urlPath,
+                        'payload' => $args,
+                        'request_time' => $finalTime - $initialTime,
+                    ]
+                );
                 self::$expectedHttpErrorCode = 400;
             }
         }

--- a/src/Helpers/HttpHelper.php
+++ b/src/Helpers/HttpHelper.php
@@ -118,7 +118,6 @@ class HttpHelper
 
                 return $clientMock->request('GET', '/');
             } finally {
-                $finalTime = round(microtime(true));
                 Logger::info(
                     LogEnum::REQUEST_HTTP_OUT,
                     [

--- a/src/Helpers/HttpHelper.php
+++ b/src/Helpers/HttpHelper.php
@@ -93,6 +93,14 @@ class HttpHelper
         // será feita a requisição normalmente.
         if ($this->isTestMode()) {
             try {
+                Logger::info(
+                    LogEnum::REQUEST_HTTP_OUT,
+                    [
+                        'base_url' => $urlHost,
+                        'http_url_request_out' => $urlPath,
+                        'payload' => $args,
+                    ]
+                );
                 if (!$this->isMockedEndpoint($urlPath)) {
                     throw new BadImplementationException(
                         ErrorEnum::PHU003,
@@ -124,21 +132,8 @@ class HttpHelper
 
         $initialTime = round(microtime(true));
         try {
-            $requestResult = $this->client->{$method}(...$args);
-            $finalTime = round(microtime(true));
-
-            Logger::info(
-                LogEnum::REQUEST_HTTP_OUT,
-                [
-                    'base_url' => $urlHost,
-                    'http_url_request_out' => $urlPath,
-                    'payload' => $args,
-                    'request_time' => $finalTime - $initialTime,
-                ]
-            );
-
-            return $requestResult;
-        } catch (Throwable $exception) {
+            return $this->client->{$method}(...$args);
+        } finally {
             $finalTime = round(microtime(true));
             Logger::info(
                 LogEnum::REQUEST_HTTP_OUT,
@@ -149,8 +144,6 @@ class HttpHelper
                     'request_time' => $finalTime - $initialTime,
                 ]
             );
-
-            throw $exception;
         }
     }
 

--- a/src/Helpers/HttpHelper.php
+++ b/src/Helpers/HttpHelper.php
@@ -92,7 +92,6 @@ class HttpHelper
         // se não estiver registro no contrato de mocks,
         // será feita a requisição normalmente.
         if ($this->isTestMode()) {
-            $initialTime = round(microtime(true));
             try {
                 if (!$this->isMockedEndpoint($urlPath)) {
                     throw new BadImplementationException(
@@ -126,7 +125,6 @@ class HttpHelper
                         'base_url' => $urlHost,
                         'http_url_request_out' => $urlPath,
                         'payload' => $args,
-                        'request_time' => $finalTime - $initialTime,
                     ]
                 );
                 self::$expectedHttpErrorCode = 400;

--- a/src/Helpers/HttpHelper.php
+++ b/src/Helpers/HttpHelper.php
@@ -80,7 +80,6 @@ class HttpHelper
      */
     public function __call($method, $args)
     {
-        $initialTime = round(microtime(true));
         $url = parse_url($args[0]);
         $urlHost = $url['host'] ?? '';
         $urlPath = $url['path'] ?? '';
@@ -123,6 +122,7 @@ class HttpHelper
             }
         }
 
+        $initialTime = round(microtime(true));
         try {
             $requestResult = $this->client->{$method}(...$args);
             $finalTime = round(microtime(true));

--- a/tests/Helpers/HttpHelperUnitTest.php
+++ b/tests/Helpers/HttpHelperUnitTest.php
@@ -397,6 +397,29 @@ class HttpHelperUnitTest extends TestCase
     /**
      * @return void
      */
+    public function testIfRequestLogSaveRequestTime(): void
+    {
+        $httpHelper = new HttpHelper();
+        $httpHelper->post('api/mocked');
+
+        $this->assertLogContent(LogEnum::REQUEST_HTTP_OUT);
+        $this->assertLogContent('request_time');
+    }
+
+    public function testRequestNotMockedSaveRequestTime(): void
+    {
+        config(['app.mode' => 'prod',]);
+        $httpHelper = new HttpHelper();
+
+        // If an error occurs, it means that the guzzle is not mocking
+        $this->expectException(Exception::class);
+        $httpHelper->post('api/not/mocked');
+        $this->assertLogContent('request_time');
+    }
+
+    /**
+     * @return void
+     */
     public function testClientInstance(): void
     {
         config([

--- a/tests/Helpers/HttpHelperUnitTest.php
+++ b/tests/Helpers/HttpHelperUnitTest.php
@@ -394,18 +394,6 @@ class HttpHelperUnitTest extends TestCase
         $this->assertLogContent('payload');
     }
 
-    /**
-     * @return void
-     */
-    public function testIfRequestLogSaveRequestTime(): void
-    {
-        $httpHelper = new HttpHelper();
-        $httpHelper->post('api/mocked');
-
-        $this->assertLogContent(LogEnum::REQUEST_HTTP_OUT);
-        $this->assertLogContent('request_time');
-    }
-
     public function testRequestNotMockedSaveRequestTime(): void
     {
         config(['app.mode' => 'prod',]);


### PR DESCRIPTION
## :package: Conteúdo

- alterado local da chamada do Logger::info
- adicionado campo de request_time no logger::info do HttpHelper

## :heavy_check_mark: Tarefa(s)

- [LOG-55667](https://logcomex.atlassian.net/browse/LOG-55667)

## :eyes: Tarefa de Code Review (CR)
- [LOG-55901](https://logcomex.atlassian.net/browse/LOG-55901)
