### PR TITLE
(LOG-55667) - Medir tempo de request para a fonte app importador

### DIFF
--- a/src/Helpers/HttpHelper.php
+++ b/src/Helpers/HttpHelper.php
@@ -130,18 +130,18 @@ class HttpHelper
             }
         }
 
-        $initialTime = round(microtime(true));
+        $initialTime = round(microtime(true) * 1000);
         try {
             return $this->client->{$method}(...$args);
         } finally {
-            $finalTime = round(microtime(true));
+            $finalTime = round(microtime(true) * 1000);
             Logger::info(
                 LogEnum::REQUEST_HTTP_OUT,
                 [
                     'base_url' => $urlHost,
                     'http_url_request_out' => $urlPath,
                     'payload' => $args,
-                    'request_time' => $finalTime - $initialTime,
+                    'request_time' => ($finalTime - $initialTime / 1000),
                 ]
             );
         }

--- a/src/Helpers/HttpHelper.php
+++ b/src/Helpers/HttpHelper.php
@@ -141,7 +141,7 @@ class HttpHelper
                     'base_url' => $urlHost,
                     'http_url_request_out' => $urlPath,
                     'payload' => $args,
-                    'request_time' => ($finalTime - $initialTime / 1000),
+                    'request_time' => ($finalTime - $initialTime) / 1000,
                 ]
             );
         }

--- a/tests/Helpers/HttpHelperUnitTest.php
+++ b/tests/Helpers/HttpHelperUnitTest.php
@@ -405,6 +405,22 @@ class HttpHelperUnitTest extends TestCase
         $this->assertLogContent('request_time');
     }
 
+    public function testRequestTimeSaveBoolean(): void
+    {
+        config(['app.mode' => 'prod',]);
+        $httpHelper = new HttpHelper();
+        try {
+            $httpHelper->post('api/not/mocked');
+        } catch (Exception $exception) {
+            // catch para não ser lançado uma excessão.
+            // se colocar um expectException ele não valida os testes feitos a baixo
+        }
+        $log = $this->getLastLogJson();
+
+        $this->assertIsFloat($log['request_time']);
+        $this->assertEquals(5, strlen((string) $log['request_time']));
+    }
+
     /**
      * @return void
      */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -139,6 +139,14 @@ abstract class TestCase extends BaseTestCase
         $logContent = file_get_contents(storage_path('logs/lumen.log'));
         $this->assertStringContainsString($expectedLogContent, $logContent);
     }
+
+    protected function getLastLogJson(): array
+    {
+        $logContent = file_get_contents(storage_path('logs/lumen.log'));
+        $explodedLogContent = explode(')', $logContent);
+
+        return json_decode($explodedLogContent[1], true);
+    }
 }
 
 /**


### PR DESCRIPTION
- alterado formato do tempo que é exibido o tempo de requisição


## :heavy_check_mark: Tarefa(s)

- [LOG-55667](https://logcomex.atlassian.net/browse/LOG-55667)

## :eyes: Tarefa de Code Review (CR)
- [LOG-55901](https://logcomex.atlassian.net/browse/LOG-55901)
