### PR TITLE
(LOG-55667) - Medir tempo de request para a fonte app importador

### DIFF
--- a/src/Helpers/HttpHelper.php
+++ b/src/Helpers/HttpHelper.php
@@ -140,7 +140,7 @@ class HttpHelper
                     'base_url' => $urlHost,
                     'http_url_request_out' => $urlPath,
                     'payload' => $args,
-                    'request_time' => ($finalTime - $initialTime / 1000),
+                    'request_time' => ($finalTime - $initialTime) / 1000,
                 ]
             );
         }

--- a/src/Helpers/HttpHelper.php
+++ b/src/Helpers/HttpHelper.php
@@ -87,15 +87,6 @@ class HttpHelper
             $args = self::propagateTracerValue($tracerValue, $args);
         }
 
-        Logger::info(
-            LogEnum::REQUEST_HTTP_OUT,
-            [
-                'base_url' => $urlHost,
-                'http_url_request_out' => $urlPath,
-                'payload' => $args,
-            ]
-        );
-
         // Tratativa criada pra endpoint mockados,
         // se não estiver registro no contrato de mocks,
         // será feita a requisição normalmente.
@@ -126,11 +117,33 @@ class HttpHelper
 
                 return $clientMock->request('GET', '/');
             } finally {
+                Logger::info(
+                    LogEnum::REQUEST_HTTP_OUT,
+                    [
+                        'base_url' => $urlHost,
+                        'http_url_request_out' => $urlPath,
+                        'payload' => $args,
+                    ]
+                );
                 self::$expectedHttpErrorCode = 400;
             }
         }
 
-        return $this->client->{$method}(...$args);
+        $initialTime = round(microtime(true) * 1000);
+        try {
+            return $this->client->{$method}(...$args);
+        } finally {
+            $finalTime = round(microtime(true) * 1000);
+            Logger::info(
+                LogEnum::REQUEST_HTTP_OUT,
+                [
+                    'base_url' => $urlHost,
+                    'http_url_request_out' => $urlPath,
+                    'payload' => $args,
+                    'request_time' => ($finalTime - $initialTime / 1000),
+                ]
+            );
+        }
     }
 
     /**

--- a/tests/Helpers/HttpHelperUnitTest.php
+++ b/tests/Helpers/HttpHelperUnitTest.php
@@ -394,6 +394,33 @@ class HttpHelperUnitTest extends TestCase
         $this->assertLogContent('payload');
     }
 
+    public function testRequestNotMockedSaveRequestTime(): void
+    {
+        config(['app.mode' => 'prod',]);
+        $httpHelper = new HttpHelper();
+
+        // If an error occurs, it means that the guzzle is not mocking
+        $this->expectException(Exception::class);
+        $httpHelper->post('api/not/mocked');
+        $this->assertLogContent('request_time');
+    }
+
+    public function testRequestTimeSaveBoolean(): void
+    {
+        config(['app.mode' => 'prod',]);
+        $httpHelper = new HttpHelper();
+        try {
+            $httpHelper->post('api/not/mocked');
+        } catch (Exception $exception) {
+            // catch para não ser lançado uma excessão.
+            // se colocar um expectException ele não valida os testes feitos a baixo
+        }
+        $log = $this->getLastLogJson();
+
+        $this->assertIsFloat($log['request_time']);
+        $this->assertEquals(5, strlen((string) $log['request_time']));
+    }
+
     /**
      * @return void
      */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -139,6 +139,14 @@ abstract class TestCase extends BaseTestCase
         $logContent = file_get_contents(storage_path('logs/lumen.log'));
         $this->assertStringContainsString($expectedLogContent, $logContent);
     }
+
+    protected function getLastLogJson(): array
+    {
+        $logContent = file_get_contents(storage_path('logs/lumen.log'));
+        $explodedLogContent = explode(')', $logContent);
+
+        return json_decode($explodedLogContent[1], true);
+    }
 }
 
 /**


### PR DESCRIPTION
- alterado formato do tempo que é exibido o tempo de requisição


## :heavy_check_mark: Tarefa(s)

- [LOG-55667](https://logcomex.atlassian.net/browse/LOG-55667)

## :eyes: Tarefa de Code Review (CR)
- [LOG-55901](https://logcomex.atlassian.net/browse/LOG-55901)
