### PR TITLE
(LOG-64189) - [Deploys] Atualizar versão do Ubuntu

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Cache Composer Downloads


### PR DESCRIPTION
## :package: Conteúdo

- [Update Ubuntu 18.04 to 20.04](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/) 

## :heavy_check_mark: Tarefa(s)

- [LOG-64189](https://logcomex.atlassian.net/browse/LOG-64189)

## :eyes: Link da tarefa de code review:

- [LOG-64191](https://logcomex.atlassian.net/browse/LOG-64191)

## :test_tube: Justificativa de No Test Needed

- Ajustes estruturais / ambiente
