### PR TITLE
(fix/treat_context_data) TreatContext na classe LogcomexLogger.php 

### DIFF
--- a/src/Loggers/LogcomexLogger.php
+++ b/src/Loggers/LogcomexLogger.php
@@ -34,7 +34,7 @@ class LogcomexLogger
             $context = array_merge($context, ExceptionHelper::exportExceptionToArray($exception));
         }
 
-        $context = json_decode(json_encode($context), true);
+        $context = json_decode(json_encode($context), true) ?? [];
         array_walk_recursive($context, function (&$value) {
             if (is_string($value)) {
                 $value = trim(str_replace("\n", " ", $value));

--- a/tests/Loggers/LogcomexLoggerUnitTest.php
+++ b/tests/Loggers/LogcomexLoggerUnitTest.php
@@ -147,6 +147,19 @@ class LogcomexLoggerUnitTest extends TestCase
 
     /**
      * @return void
+     * @throws Exception
+     */
+    public function testTreatContextWhenContextIsNotAbleToJsonDecode(): void
+    {
+        $context = random_bytes(20);
+        $response = LogcomexLogger::treatContext($context);
+
+        $this->assertIsArray($response);
+        $this->assertEmpty($response);
+    }
+
+    /**
+     * @return void
      */
     public function testInfoWithContextArraySuccessFlow(): void
     {


### PR DESCRIPTION
## :package: Conteúdo

- TreatContext na classe LogcomexLogger.php para quando json_decode retornar null, passar para array vazio para não quebrar o array_walk_recursive

## :heavy_check_mark: Tarefa(s)

- LOG-XXXX

## :eyes: Tarefa de Code Review (CR)
- LOG-XXXX
